### PR TITLE
feat(config): [input] の min/max 対称性を validate で検証 (ROB-7)

### DIFF
--- a/DESIGN/06-config-schema.md
+++ b/DESIGN/06-config-schema.md
@@ -233,3 +233,4 @@ close_button           threshold=0.93  roi=(0.20,0.50,0.60,0.45)
 | ポーリング間隔 (default/post_battle/debounce) ≥ 100ms | 同上 |
 | `stability_poll_ms ≥ 50ms` | 同上 |
 | `loop.coord_cache.search_pad_px ∈ [1, 256]` | 同上 (DESIGN/11 §11.7) |
+| `[input]` min/max ペアが `min ≤ max` (`click_press_duration_*_ms` / `pre_click_*_ms` / `post_click_*_ms`) | 同上 (TOML 編集ミスで逆転した値を起動時に弾く) |

--- a/src/config.rs
+++ b/src/config.rs
@@ -421,6 +421,39 @@ impl Config {
             )));
         }
 
+        // --- min <= max の対称性 ([input] の min/max ペア) ---
+        // `humanize::random_press_duration_ms` 等は逆転時に安全側で min を返すが、
+        // TOML 編集ミス (例: pre_click_min_ms=300, pre_click_max_ms=150) を
+        // 起動前に検出する方が望ましい。ここで機械的に弾く。
+        let i = &self.input;
+        for (label_min, v_min, label_max, v_max) in [
+            (
+                "click_press_duration_min_ms",
+                i.click_press_duration_min_ms,
+                "click_press_duration_max_ms",
+                i.click_press_duration_max_ms,
+            ),
+            (
+                "pre_click_min_ms",
+                i.pre_click_min_ms,
+                "pre_click_max_ms",
+                i.pre_click_max_ms,
+            ),
+            (
+                "post_click_min_ms",
+                i.post_click_min_ms,
+                "post_click_max_ms",
+                i.post_click_max_ms,
+            ),
+        ] {
+            if v_min > v_max {
+                return Err(BotError::Config(format!(
+                    "input.{} ({}) must be <= input.{} ({})",
+                    label_min, v_min, label_max, v_max
+                )));
+            }
+        }
+
         Ok(())
     }
 }
@@ -571,5 +604,49 @@ mod tests {
         // 捨てないため、最低 3 回は耐える挙動を維持する)。
         assert_eq!(default_capture_retry_threshold(), 3);
         assert_eq!(PollConfig::default().capture_retry_threshold, 3);
+    }
+
+    // === [input] min/max 対称性 (ROB-7) ===
+
+    #[test]
+    fn validate_rejects_inverted_click_press_duration() {
+        let mut cfg = base_config();
+        cfg.input.click_press_duration_min_ms = 200;
+        cfg.input.click_press_duration_max_ms = 100;
+        let err = cfg.validate().unwrap_err();
+        let msg = format!("{}", err);
+        assert!(msg.contains("click_press_duration_min_ms"));
+        assert!(msg.contains("click_press_duration_max_ms"));
+    }
+
+    #[test]
+    fn validate_rejects_inverted_pre_click_range() {
+        let mut cfg = base_config();
+        cfg.input.pre_click_min_ms = 300;
+        cfg.input.pre_click_max_ms = 150;
+        let err = cfg.validate().unwrap_err();
+        let msg = format!("{}", err);
+        assert!(msg.contains("pre_click_min_ms"));
+        assert!(msg.contains("pre_click_max_ms"));
+    }
+
+    #[test]
+    fn validate_rejects_inverted_post_click_range() {
+        let mut cfg = base_config();
+        cfg.input.post_click_min_ms = 800;
+        cfg.input.post_click_max_ms = 400;
+        let err = cfg.validate().unwrap_err();
+        let msg = format!("{}", err);
+        assert!(msg.contains("post_click_min_ms"));
+        assert!(msg.contains("post_click_max_ms"));
+    }
+
+    #[test]
+    fn validate_accepts_equal_min_max() {
+        // min == max は退化的だが「逆転ではない」ので許容する。
+        let mut cfg = base_config();
+        cfg.input.pre_click_min_ms = 200;
+        cfg.input.pre_click_max_ms = 200;
+        assert!(cfg.validate().is_ok());
     }
 }


### PR DESCRIPTION
## Summary

`Config::validate` で `[input]` の 3 ペア (`click_press_duration_*_ms` / `pre_click_*_ms` / `post_click_*_ms`) について `min <= max` を機械的に検証する。

- src/config.rs::Config::validate: input の min/max ペアを 3 件チェックするループを追加
- DESIGN/06-config-schema.md: バリデーション項目テーブルに追記

`min == max` は退化的だが「逆転ではない」ので許容する。

## Test plan

- [x] `cargo test --workspace --lib` 30 件 PASS (元 26 + ROB-7 4件: 3 ペア各々の逆転拒否 + min==max 許容)

Closes #6