### PR TITLE
fix(security): templates.file のパストラバーサルを起動時に拒否 (SEC-1)

### DIFF
--- a/DESIGN/04-vision-and-templates.md
+++ b/DESIGN/04-vision-and-templates.md
@@ -41,6 +41,13 @@ impl TemplateLibrary {
 を出力する。テンプレディレクトリが存在しない、ファイルが見つからない場合は
 起動時に `BotError::Config` で停止。
 
+**パストラバーサル対策**: `templates_dir.join(&cfg.file)` で `cfg.file` が
+`..` や絶対パス / ドライブレター (`C:\...`, `\\server\share`) を含むと
+任意ファイル読み込みになり、共有 TOML 経由のサプライチェーン懸念がある。
+このため `Config::validate` 側で `Path::components()` を走査し、
+`Component::Normal` と `Component::CurDir` 以外を含む `file` は
+`BotError::Config` で起動拒否する (`load_from_dir` 到達前に阻止)。
+
 ### Match (`vision/matcher.rs`)
 
 ```rust

--- a/DESIGN/06-config-schema.md
+++ b/DESIGN/06-config-schema.md
@@ -197,6 +197,10 @@ roi = { x_pct = 0.0, y_pct = 0.0, w_pct = 1.0, h_pct = 1.0 }   # optional
 | `roi` | `Option<RoiPct>` | None (画面全体) | クライアント領域に対する比率 |
 
 **バリデーション (全テンプレ共通)**:
+- `file` のパスコンポーネントが `Component::Normal` / `Component::CurDir` 以外
+  （`..`、ドライブレター `C:\`、絶対パス `/...`、UNC `\\server\share` 等）を含む → 失敗
+  - 理由: `templates_dir.join(&file)` で任意ファイルが読み込まれる
+    パス・トラバーサルを防止 (共有 TOML のサプライチェーン懸念)
 - `threshold` が NaN/Inf または `[0.0, 1.0]` 外 → `BotError::Config`
 - `roi.{x_pct, y_pct, w_pct, h_pct}` が NaN/Inf または `[0.0, 1.0]` 外 → 失敗
 - `roi.w_pct <= 0.0 || roi.h_pct <= 0.0` → 失敗
@@ -230,6 +234,7 @@ close_button           threshold=0.93  roi=(0.20,0.50,0.60,0.45)
 | `reisseki_zero_guard.roi` が必ず指定されている | 同上 |
 | 全テンプレの `threshold ∈ [0.0, 1.0]` | 同上 |
 | 全テンプレの `roi.*_pct ∈ [0.0, 1.0]`、`w_pct,h_pct > 0` | 同上 |
+| 全テンプレの `file` が `..` / 絶対パス / ドライブレターを含まない (パストラバーサル防止) | 同上 |
 | ポーリング間隔 (default/post_battle/debounce) ≥ 100ms | 同上 |
 | `stability_poll_ms ≥ 50ms` | 同上 |
 | `loop.coord_cache.search_pad_px ∈ [1, 256]` | 同上 (DESIGN/11 §11.7) |

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
 
@@ -336,6 +336,23 @@ impl Config {
     pub fn validate(&self) -> Result<()> {
         // --- テンプレ全般 ---
         for (name, t) in &self.templates {
+            // `templates_dir.join(&t.file)` で `t.file` が `..` や絶対パス・
+            // ドライブレターを含むと任意ファイル読み込みになり、共有 TOML 経由で
+            // 別ファイルを差し替えられるサプライチェーン懸念がある。
+            // `Component::Normal`（と `CurDir` = `.`）のみ許可。
+            for component in Path::new(&t.file).components() {
+                match component {
+                    Component::Normal(_) | Component::CurDir => {}
+                    _ => {
+                        return Err(BotError::Config(format!(
+                            "template '{}': file '{}' must be a plain relative path \
+                             (no '..', no drive/root prefix); got component {:?}",
+                            name, t.file, component
+                        )));
+                    }
+                }
+            }
+
             if !t.threshold.is_finite() || !(0.0..=1.0).contains(&t.threshold) {
                 return Err(BotError::Config(format!(
                     "template '{}': threshold {} not finite or out of [0.0, 1.0]",
@@ -647,6 +664,58 @@ mod tests {
         let mut cfg = base_config();
         cfg.input.pre_click_min_ms = 200;
         cfg.input.pre_click_max_ms = 200;
+        assert!(cfg.validate().is_ok());
+    }
+
+    // === templates.file パストラバーサル (SEC-1) ===
+
+    #[test]
+    fn validate_rejects_template_file_with_parent_dir() {
+        let mut cfg = base_config();
+        cfg.templates.insert(
+            "evil".into(),
+            TemplateConfig {
+                file: "../../../Windows/system.ini".into(),
+                threshold: 0.93,
+                roi: None,
+            },
+        );
+        let err = cfg.validate().unwrap_err();
+        let msg = format!("{}", err);
+        assert!(msg.contains("evil"), "msg = {}", msg);
+        assert!(msg.contains(".."), "msg = {}", msg);
+    }
+
+    #[test]
+    fn validate_rejects_template_file_with_absolute_path() {
+        let mut cfg = base_config();
+        cfg.templates.insert(
+            "evil".into(),
+            TemplateConfig {
+                file: "/etc/passwd".into(),
+                threshold: 0.93,
+                roi: None,
+            },
+        );
+        let err = cfg.validate().unwrap_err();
+        let msg = format!("{}", err);
+        assert!(msg.contains("evil"), "msg = {}", msg);
+        // RootDir コンポーネントが拒否される (Linux/Windows 共通)。
+        assert!(msg.contains("plain relative path"), "msg = {}", msg);
+    }
+
+    #[test]
+    fn validate_accepts_template_file_subdirectory() {
+        // 通常のサブディレクトリ参照 (`Component::Normal` のみで構成) は許可される。
+        let mut cfg = base_config();
+        cfg.templates.insert(
+            "nested".into(),
+            TemplateConfig {
+                file: "subdir/foo.png".into(),
+                threshold: 0.93,
+                roi: None,
+            },
+        );
         assert!(cfg.validate().is_ok());
     }
 }


### PR DESCRIPTION
## Summary

`templates_dir.join(&t.file)` 経由のパストラバーサル攻撃を起動時に阻止する。

- src/config.rs::Config::validate: 全テンプレで `Path::components()` を検査。`Component::Normal` と `Component::CurDir` (`.`) 以外を含む `file` は `BotError::Config` で起動拒否
- DESIGN/04-vision-and-templates.md: パストラバーサル対策の説明節を追加
- DESIGN/06-config-schema.md: バリデーション項目とテーブルに追記

通常のサブディレクトリ (`subdir/foo.png`) は `Component::Normal` のみで構成されるため許可される。

## Test plan

- [x] `cargo test --workspace --lib` 33 件 PASS (元 30 + SEC-1 3件: `..` 拒否 / `/etc/passwd` 拒否 / サブディレクトリ許可)

Closes #8