### PR TITLE
feat(vision): coord cache フォールバックのログを観測しやすく改善

### DIFF
--- a/DESIGN/11-coord-cache.md
+++ b/DESIGN/11-coord-cache.md
@@ -273,8 +273,17 @@ fn default_coord_cache_relax_stability_on_hit() -> bool { false }
 **サイクル末サマリ (INFO):**
 
 ```
-coord cache: hits=5 small_roi_miss_fallback=1 (succeeded=1 failed=0) invalidations=0 entries=4
+coord cache: hits=5 misses=1 (recovered=1 still_missing=0) invalidations=0 entries=4
 ```
+
+| 表示語 | 内部フィールド | 意味 |
+|---|---|---|
+| `hits` | `stats.hits` | 小 ROI で stability check を通過しクリックに至った回数 |
+| `misses` | `stats.small_roi_misses` | 小 ROI で未検出 → 大 ROI へフォールバック発動した回数 |
+| `recovered` | `stats.fallback_succeeded` | 大 ROI フォールバックで本物が見つかった回数 (cache evict 済) |
+| `still_missing` | `stats.fallback_failed` | 大 ROI でも見つからなかった回数 (画面遷移途中の可能性、次 poll で retry) |
+| `invalidations` | `stats.invalidations` | クライアント (W,H) 変動で全エントリを破棄した回数 |
+| `entries` | `entries.len()` | 現在キャッシュに乗っているテンプレ数 |
 
 `run_one_cycle` の return 直前に 1 行出す (累積、サイクル間で持続)。
 
@@ -282,9 +291,10 @@ coord cache: hits=5 small_roi_miss_fallback=1 (succeeded=1 failed=0) invalidatio
 
 | 場面 | レベル | 例 |
 |---|---|---|
-| キャッシュヒット (stable で click 発行直前) | INFO | `info!("{name} cache hit: small ROI ({x},{y}) {w}x{h} score={:.4}")` |
-| 小 ROI ミス → 大 ROI フォールバック開始 | INFO | `info!("{name} small ROI miss (best={:.4}) — falling back to full ROI")` |
-| 大 ROI フォールバック成功 | INFO | `info!("{name} fallback hit at ({cx},{cy}) — refreshing cache")` |
+| キャッシュヒット (stable で click 発行直前) | INFO | `info!("{name} cache hit: clicked at ({x},{y}) score={:.4}")` |
+| 小 ROI ミス → 大 ROI フォールバック開始 | INFO | `info!("{name} small ROI miss (best={:.4} < threshold={:.4}) — falling back to full ROI")` |
+| 大 ROI フォールバック成功 | INFO | `info!("{name} fallback recovered (score={:.4}) — refreshing cache on stable click")` |
+| 大 ROI フォールバックも空振り | WARN | `warn!("{name} fallback also missed (best={:.4} < threshold={:.4}) — likely transition not settled, will retry")` |
 | baseline 変動による全破棄 | WARN | `warn!("client size changed {Wp}x{Hp} → {Wn}x{Hn} — invalidating coord cache (entries={N})")` |
 | 通常 ROI 探索 (キャッシュ無し) | DEBUG | 既存 `match '{name}': search rect ...` をそのまま流用 |
 

--- a/src/bot/sequence.rs
+++ b/src/bot/sequence.rs
@@ -256,7 +256,7 @@ impl BotEngine {
             let cache = self.coord_cache.borrow();
             let s = cache.stats();
             tracing::info!(
-                "coord cache: hits={} small_roi_miss_fallback={} (succeeded={} failed={}) invalidations={} entries={}",
+                "coord cache: hits={} misses={} (recovered={} still_missing={}) invalidations={} entries={}",
                 s.hits,
                 s.small_roi_misses,
                 s.fallback_succeeded,
@@ -534,19 +534,26 @@ impl BotEngine {
             if matched.is_none() && cache_hit_path {
                 self.coord_cache.borrow_mut().note_small_roi_miss();
                 tracing::info!(
-                    "{} small ROI miss (best={:.4}) — falling back to full ROI",
-                    name, score
+                    "{} small ROI miss (best={:.4} < threshold={:.4}) — falling back to full ROI",
+                    name, score, tpl.threshold
                 );
                 let (m2, s2) = self.matcher.find_in_rect(&gray, tpl, roi_full);
                 if m2.is_some() {
                     self.coord_cache.borrow_mut().note_fallback_succeeded();
                     self.coord_cache.borrow_mut().evict(name);
                     tracing::info!(
-                        "{} fallback hit (score={:.4}) — refreshing cache on stable click",
+                        "{} fallback recovered (score={:.4}) — refreshing cache on stable click",
                         name, s2
                     );
                 } else {
                     self.coord_cache.borrow_mut().note_fallback_failed();
+                    // フォールバックでも見つからなかった = 画面遷移途中の可能性が高い。
+                    // 次の poll で再試行されるため致命ではないが、繰り返し出る場合は
+                    // 遷移待ちの sleep 値や ROI 設定を見直す指標になる。
+                    tracing::warn!(
+                        "{} fallback also missed (best={:.4} < threshold={:.4}) — likely transition not settled, will retry",
+                        name, s2, tpl.threshold
+                    );
                 }
                 matched = m2;
                 score = s2;


### PR DESCRIPTION
## Summary

PR [#1](https://github.com/nok0321/dmm-game-bot-rs/pull/1) のコメントで指摘されたサマリログの違和感 (`succeeded=0 failed=1` の意味が直感に反する) を解消する。実装ロジック・カウンタは正しいので、ログ表示語と説明だけを改善する。

- サマリログ: `small_roi_miss_fallback` → `misses` / `succeeded` → `recovered` / `failed` → `still_missing`
- `small ROI miss` ログに `threshold` 値を追加
- fallback 失敗時に WARN ログを追加: `fallback also missed (best=... < threshold=...) — likely transition not settled, will retry`
- DESIGN/11 §11.8 に「表示語 ↔ 内部フィールド」対応表を追加

`CoordCacheStats` の構造体フィールド名 (`fallback_succeeded` / `fallback_failed`) は互換性のため変更していない。

## 改善前後

```
旧: coord cache: hits=4 small_roi_miss_fallback=1 (succeeded=0 failed=1) invalidations=0 entries=4
新: coord cache: hits=4 misses=1 (recovered=0 still_missing=1) invalidations=0 entries=4
```

加えて、`still_missing` がカウントされた瞬間に WARN ログが出るので、画面遷移途中で踏んだケースが目視で即座に分かる。

## Test plan

- [x] `cargo test --workspace --lib` 33 件 PASS (回帰なし、ログ文言は既存テストの対象外)
- [ ] 次回の実機 `--max-cycles 2 --live` で新フォーマットが出ることを目視確認 (リリース後)

Closes #12